### PR TITLE
chore: Add duplicate package checker plugin

### DIFF
--- a/packages/cozy-scripts/config/webpack.bundle.default.js
+++ b/packages/cozy-scripts/config/webpack.bundle.default.js
@@ -16,6 +16,7 @@ const configs = [
   require('./webpack.config.vendors'),
   require('./webpack.config.manifest'),
   require('./webpack.config.progress'),
+  require('./webpack.config.duplicates'),
   addAnalyzer ? require('./webpack.config.analyzer') : null,
   require('./webpack.config.services'),
   require(`./webpack.target.${target}`)

--- a/packages/cozy-scripts/config/webpack.config.duplicates.js
+++ b/packages/cozy-scripts/config/webpack.config.duplicates.js
@@ -1,0 +1,7 @@
+'use strict'
+
+const DuplicatePackageCheckerPlugin = require('duplicate-package-checker-webpack-plugin')
+
+module.exports = {
+  plugins: [new DuplicatePackageCheckerPlugin()]
+}

--- a/packages/cozy-scripts/package.json
+++ b/packages/cozy-scripts/package.json
@@ -31,6 +31,7 @@
     "css-loader": "2.1.0",
     "css-mqpacker": "7.0.0",
     "csswring": "7.0.0",
+    "duplicate-package-checker-webpack-plugin": "^3.0.0",
     "eslint": "5.9.0",
     "eslint-config-cozy-app": "1.5.0",
     "eslint-loader": "2.1.2",

--- a/packages/cozy-scripts/yarn.lock
+++ b/packages/cozy-scripts/yarn.lock
@@ -2372,7 +2372,7 @@ chalk@3:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.4.1, chalk@^2.4.2:
+chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.0, chalk@^2.4.1, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
   integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
@@ -3279,6 +3279,16 @@ duplexify@^3.4.2, duplexify@^3.6.0:
     readable-stream "^2.0.0"
     stream-shift "^1.0.0"
 
+duplicate-package-checker-webpack-plugin@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/duplicate-package-checker-webpack-plugin/-/duplicate-package-checker-webpack-plugin-3.0.0.tgz#78bb89e625fa7cf8c2a59c53f62b495fda9ba287"
+  integrity sha512-aO50/qPC7X2ChjRFniRiscxBLT/K01bALqfcDaf8Ih5OqQ1N4iT/Abx9Ofu3/ms446vHTm46FACIuJUmgUQcDQ==
+  dependencies:
+    chalk "^2.3.0"
+    find-root "^1.0.0"
+    lodash "^4.17.4"
+    semver "^5.4.1"
+
 ecc-jsbn@~0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz#3a83a904e54353287874c564b7549386849a98c9"
@@ -4031,6 +4041,11 @@ find-cache-dir@^2.1.0:
     commondir "^1.0.1"
     make-dir "^2.0.0"
     pkg-dir "^3.0.0"
+
+find-root@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/find-root/-/find-root-1.1.0.tgz#abcfc8ba76f708c42a97b3d685b7e9450bfb9ce4"
+  integrity sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==
 
 find-up@^1.0.0:
   version "1.1.2"
@@ -5879,6 +5894,11 @@ lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
+
+lodash@^4.17.4:
+  version "4.17.20"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
+  integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
 
 loglevel@^1.6.6:
   version "1.6.7"


### PR DESCRIPTION
Outputs warnings if libraries are multiple times in a bundle.

For example in [contacts](https://github.com/cozy/cozy-contacts).

```
    WARNING in hoist-non-react-statics
      Multiple versions of hoist-non-react-statics found:
        2.5.5 ./~/cozy-client/~/hoist-non-react-statics
        3.3.0 ./~/hoist-non-react-statics
    
    
    WARNING in lodash
      Multiple versions of lodash found:
        4.17.13 ./~/cozy-device-helper/~/lodash
        4.17.14 ./~/cozy-client/~/lodash
        4.17.15 ./~/lodash
    
    
    WARNING in prop-types
      Multiple versions of prop-types found:
        15.6.2 ./~/cozy-client/~/prop-types
        15.7.2 ./~/prop-types
    
    
    WARNING in react
      Multiple versions of react found:
        16.7.0 ./~/cozy-client/~/react
        16.8.6 /Users/cozy/code/cozy/create-cozy-app/packages/cozy-scripts/~/react
    
    
    WARNING in regenerator-runtime
      Multiple versions of regenerator-runtime found:
        0.10.5 ./~/babel-polyfill/~/regenerator-runtime
        0.11.1 ./~/babel-runtime/~/regenerator-runtime
        0.13.2 ./~/@babel/runtime/~/regenerator-runtime
    
    
    WARNING in unist-util-visit-parents
      Multiple versions of unist-util-visit-parents found:
        1.1.2 ./~/unist-util-visit-parents
        2.1.2 ./~/unist-util-visit/~/unist-util-visit-parents
    
    
    WARNING in warning
      Multiple versions of warning found:
        3.0.0 ./~/warning
        4.0.3 ./~/node-polyglot/~/warning
```

Useful to detect libraries that are too strict in their package.json (mostly ours).