### PR TITLE
fix: Call method when needed not before

### DIFF
--- a/packages/cozy-scripts/config/webpack.config.assets.js
+++ b/packages/cozy-scripts/config/webpack.config.assets.js
@@ -28,7 +28,7 @@ module.exports = {
     new CopyPlugin([
       {
         from: appIconPath,
-        to: hasPublic
+        to: hasPublic()
           ? path.join(paths.appBuild(), publicFolderName, manifest.icon)
           : path.join(paths.appBuild(), manifest.icon),
         transform: buffer => svgo.optimize(buffer).then(resp => resp.data)

--- a/packages/cozy-scripts/config/webpack.config.manifest.js
+++ b/packages/cozy-scripts/config/webpack.config.manifest.js
@@ -46,7 +46,7 @@ function transformManifest(buffer) {
   }
   // icon will be stored in public folder for app with public page
   if (
-    hasPublic &&
+    hasPublic() &&
     content.icon &&
     !content.icon.match(new RegExp(`${publicFolderName}/`))
   ) {

--- a/packages/cozy-scripts/config/webpack.config.public.js
+++ b/packages/cozy-scripts/config/webpack.config.public.js
@@ -15,11 +15,8 @@ const appName = manifest.name_prefix
   ? `${manifest.name_prefix} ${manifest.name}`
   : manifest.name
 
-/* We don't build public if no public and if on mobile build */
-const addPublicConfig = hasPublic && target === 'browser'
-
 function getConfig() {
-  return addPublicConfig
+  return hasPublic() && target === 'browser'
     ? {
         entry: {
           // since the file extension depends on the framework here

--- a/packages/cozy-scripts/config/webpack.environment.dev.js
+++ b/packages/cozy-scripts/config/webpack.environment.dev.js
@@ -12,7 +12,7 @@ const {
   publicFolderName
 } = require('./webpack.vars')
 
-const devAssetFolder = hasPublic
+const devAssetFolder = hasPublic()
   ? `${publicFolderName}/${assetsFolderName}`
   : assetsFolderName
 

--- a/packages/cozy-scripts/config/webpack.vars.js
+++ b/packages/cozy-scripts/config/webpack.vars.js
@@ -30,9 +30,10 @@ const useClientJS =
   !!(pkg.dependencies && pkg.dependencies['cozy-client-js']) ||
   !!(pkg.devDependencies && pkg.devDependencies['cozy-client-js'])
 
-const hasPublic =
+const hasPublic = () =>
   fs.existsSync(paths.appPublicIndex()) &&
   fs.existsSync(paths.appPublicHtmlTemplate())
+
 const publicFolderName = 'public'
 
 const assetsFolderName = 'assets'


### PR DESCRIPTION
Current master branch is failing creating public assets mainly because we're calling `hasPublic` https://github.com/cozy/create-cozy-app/blob/92601f644474be69174903f32d571ed1985e02ca/packages/cozy-scripts/config/webpack.vars.js#L33  during launch time.

`hasPublic` call https://github.com/cozy/create-cozy-app/blob/92601f644474be69174903f32d571ed1985e02ca/packages/cozy-scripts/utils/paths.js#L20, but `process.env[CTS.ENTRY_EXT]` is not yet set, so hasPublic is failing since it fallbacks to `index.js` and not `index.jsx`

By calling hasPublic when needed seems to work 