### PR TITLE
Move dependencies outside the app

### DIFF
--- a/packages/cozy-scripts/package.json
+++ b/packages/cozy-scripts/package.json
@@ -4,14 +4,16 @@
   "scripts": {},
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/CPatchane/create-cozy-app.git"
+    "url": "git+https://github.com/cozy/create-cozy-app.git"
   },
-  "homepage": "https://github.com/CPatchane/create-cozy-app#readme",
-  "author": "CPatchane <code@patchane.com>",
-  "contributors": [],
+  "homepage": "https://github.com/cozy/create-cozy-app#readme",
+  "author": "Cozy <contact@cozycloud.cc>",
+  "contributors": [
+    "CPatchane <code@patchane.com>"
+  ],
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/CPatchane/create-cozy-app/issues"
+    "url": "https://github.com/cozy/create-cozy-app/issues"
   },
   "dependencies": {
     "@babel/core": "7.2.2",

--- a/packages/cozy-scripts/package.json
+++ b/packages/cozy-scripts/package.json
@@ -31,6 +31,8 @@
     "css-mqpacker": "7.0.0",
     "csswring": "7.0.0",
     "eslint": "5.9.0",
+    "eslint-plugin-prettier": "3.0.1",
+    "eslint-plugin-react": "7.12.4",
     "eslint-config-cozy-app": "1.1.8",
     "eslint-loader": "2.1.2",
     "expose-loader": "0.7.5",

--- a/packages/cozy-scripts/template/package.json
+++ b/packages/cozy-scripts/template/package.json
@@ -33,8 +33,6 @@
     "babel-preset-cozy-app": "1.2.5",
     "enzyme": "3.8.0",
     "enzyme-adapter-react-16": "1.9.1",
-    "eslint-plugin-prettier": "3.0.1",
-    "eslint-plugin-react": "7.12.4",
     "git-directory-deploy": "1.5.1",
     "prettier": "1.15.3",
     "react-hot-loader": "4.6.5",
@@ -46,7 +44,6 @@
     "cozy-bar": "6.12.0",
     "cozy-client": "6.0.0",
     "cozy-ui": "17.6.0",
-    "eslint-config-cozy-app": "1.1.8",
     "react": "16.8.1",
     "react-dom": "16.8.1",
     "react-router-dom": "4.3.1"


### PR DESCRIPTION
When I used cozy-scripts in Banks, I had to install 
eslint-plugin-prettier. AMHA since this is cozy-scripts
that needs it, it should not be installed via the app.

cozy-scripts bears all the tooling dependencies so that
the app can forget about that.