### PR TITLE
Remove PostCSS's MQPacker plugin

### DIFF
--- a/packages/cozy-scripts/config/webpack.config.base.js
+++ b/packages/cozy-scripts/config/webpack.config.base.js
@@ -69,7 +69,6 @@ module.exports = {
       test: /\.css$/,
       log: isDebugMode,
       plugins: [
-        require('css-mqpacker'),
         require('postcss-discard-duplicates'),
         require('postcss-discard-empty')
       ].concat(

--- a/packages/cozy-scripts/package.json
+++ b/packages/cozy-scripts/package.json
@@ -28,7 +28,6 @@
     "copy-webpack-plugin": "4.6.0",
     "cross-spawn": "6.0.5",
     "css-loader": "2.1.0",
-    "css-mqpacker": "7.0.0",
     "csswring": "7.0.0",
     "eslint": "5.9.0",
     "eslint-config-cozy-app": "1.5.0",

--- a/packages/cozy-scripts/yarn.lock
+++ b/packages/cozy-scripts/yarn.lock
@@ -2171,14 +2171,6 @@ css-loader@2.1.0:
     postcss-value-parser "^3.3.0"
     schema-utils "^1.0.0"
 
-css-mqpacker@7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/css-mqpacker/-/css-mqpacker-7.0.0.tgz#48f4a0ff45b81ec661c4a33ed80b9db8a026333b"
-  integrity sha512-temVrWS+sB4uocE2quhW8ru/KguDmGhCU7zN213KxtDvWOH3WS/ZUStfpF4fdCT7W8fPpFrQdWRFqtFtPPfBLA==
-  dependencies:
-    minimist "^1.2.0"
-    postcss "^7.0.0"
-
 css-parse@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/css-parse/-/css-parse-2.0.0.tgz#a468ee667c16d81ccf05c58c38d2a97c780dbfd4"


### PR DESCRIPTION
MQPacker merges media queries in order to save some space. In doing so,
it can reorder media queries. When writing a CSS file, order is important,
particularly when working with media queries. MQPacker removes this
important fact about CSS which trigger unexpected bugs: last in date for
me was a table was overflowing from the page because `width` directives
had been reordered.

```
<!-- 1 -->
@media (max-width: 700px) {
  .td-1 {
    background: blue;
  }
}

<!-- 2 -->
@media (max-width: 540px) {
  .td-1 {
    background: red;
  }
}
```

If the content of the media queries is reordered so that "2" is before "1", 
"2" will never be able to overwrite what "1" says. See https://jsbin.com/xarogaj/1/edit?html,css,js,output
for the above example.


In Banks, I've worked around this problem by removing the plugin from
the config with a dirty hack:

```
const mqpacker = require('css-mqpacker')

const removeCSSMQPackerPlugin = config => {
  config.plugins.forEach(plugin => {
    if (plugin.constructor.name === 'PostCSSAssetsPlugin') {
      const prevLength = plugin.plugins.length
      plugin.plugins = plugin.plugins.filter(
        postcssPlugin => postcssPlugin !== mqpacker
      )
      if (prevLength > plugin.plugins.length) {
        // eslint-disable-next-line no-console
        console.log('Removed mqpacker plugin from PostCSSAssetsPlugin')
      }
    }
  })
}

removeCSSMQPackerPlugin(config)
```

We've already had to deal with too many bugs due to mqpacker, let's remove it.