### PR TITLE
feat: Automatically provide the bar via ProvidePlugin if used through cozy.bar

### DIFF
--- a/packages/cozy-scripts/config/webpack.environment.dev.js
+++ b/packages/cozy-scripts/config/webpack.environment.dev.js
@@ -1,14 +1,39 @@
 'use strict'
 
 const webpack = require('webpack')
+const merge = require('webpack-merge')
 const { useHotReload, devtool } = require('./webpack.vars')
 
 let plugins = [
   new webpack.DefinePlugin({
-    __DEVELOPMENT__: true,
-    __STACK_ASSETS__: false
+    __DEVELOPMENT__: true
   })
 ]
+
+// In development, the bar is provided automatically. We use the ProvidePlugin
+// since it allows us to use in production the cozy.bar declared by the <script />
+// line injected by the stack, while in developement to have it "served" from
+// our node_modules
+const barConfig = {
+  plugins: [
+    new webpack.DefinePlugin({
+      __STACK_ASSETS__: false
+    }),
+    new webpack.ProvidePlugin({
+      'cozy.bar': 'cozy-bar/dist/cozy-bar.min.js'
+    })
+  ],
+  module: {
+    rules: [
+      {
+        test: /cozy-bar\/dist\/cozy-bar\.min\.js$/,
+        // Automatically import the CSS if the JS is imported.
+        // imports-loader@0.8.0 works but imports-loader@1.0.0 does not
+        loader: 'imports-loader?css=./cozy-bar.min.css'
+      }
+    ]
+  }
+}
 
 let output = {}
 if (useHotReload) {
@@ -16,14 +41,17 @@ if (useHotReload) {
   output.globalObject = 'this'
 }
 
-module.exports = {
-  devtool: devtool || 'cheap-module-eval-source-map',
-  mode: 'development',
-  externals: ['cozy'],
-  plugins,
-  output,
-  optimization: {
-    removeAvailableModules: false,
-    removeEmptyChunks: false
-  }
-}
+module.exports = merge(
+  {
+    devtool: devtool || 'cheap-module-eval-source-map',
+    mode: 'development',
+    externals: ['cozy'],
+    plugins,
+    output,
+    optimization: {
+      removeAvailableModules: false,
+      removeEmptyChunks: false
+    }
+  },
+  barConfig
+)

--- a/packages/cozy-scripts/package.json
+++ b/packages/cozy-scripts/package.json
@@ -42,6 +42,7 @@
     "html-webpack-include-assets-plugin": "1.0.7",
     "html-webpack-plugin": "3.2.0",
     "identity-obj-proxy": "3.0.0",
+    "imports-loader": "0.8.0",
     "jest": "24.9.0",
     "json-loader": "0.5.7",
     "mini-css-extract-plugin": "0.5.0",

--- a/packages/cozy-scripts/yarn.lock
+++ b/packages/cozy-scripts/yarn.lock
@@ -4065,6 +4065,14 @@ import-local@^2.0.0:
     pkg-dir "^3.0.0"
     resolve-cwd "^2.0.0"
 
+imports-loader@0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/imports-loader/-/imports-loader-0.8.0.tgz#030ea51b8ca05977c40a3abfd9b4088fe0be9a69"
+  integrity sha512-kXWL7Scp8KQ4552ZcdVTeaQCZSLW+e6nJfp3cwUMB673T7Hr98Xjx5JK+ql7ADlJUvj1JS5O01RLbKoutN5QDQ==
+  dependencies:
+    loader-utils "^1.0.2"
+    source-map "^0.6.1"
+
 imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"


### PR DESCRIPTION
In 5edd75114, a refactor to extract the public config caused the bar not
to be injected automatically through HtmlWebpackIncludeAssetsPlugin anymore.
This caused `cozy.bar is undefined` problems.

Here, we inject the bar through the ProvidePlugin and automatically inject
the bar's CSS through imports-loader. I refactored a bit to make it clear
that the STACK_ASSETS variable defined to be used in the HTML template is
related to the bar config.

This feature will allow banks to remove its custom code : https://github.com/cozy/cozy-banks/blob/63054a75efd1681f14b36c488f8569b0569d7738/webpack.config.js#L13