### PR TITLE
fix: Provide cozyclientjs in dev mode

### DIFF
--- a/packages/cozy-scripts/config/webpack.environment.dev.js
+++ b/packages/cozy-scripts/config/webpack.environment.dev.js
@@ -10,17 +10,18 @@ let plugins = [
   })
 ]
 
-// In development, the bar is provided automatically. We use the ProvidePlugin
-// since it allows us to use in production the cozy.bar declared by the <script />
+// In development, the bar and cozyclientjs are provided automatically. We use the ProvidePlugin
+// since it allows us to use in production the cozy.bar and cozy.client declared by the <script />
 // line injected by the stack, while in developement to have it "served" from
 // our node_modules
-const barConfig = {
+const stackProvidedLibsConfig = {
   plugins: [
     new webpack.DefinePlugin({
       __STACK_ASSETS__: false
     }),
     new webpack.ProvidePlugin({
-      'cozy.bar': 'cozy-bar/dist/cozy-bar.min.js'
+      'cozy.bar': 'cozy-bar/dist/cozy-bar.min.js',
+      'cozy.client': 'cozy-client-js/dist/cozy-client.min.js'
     })
   ],
   module: {
@@ -53,5 +54,5 @@ module.exports = merge(
       removeEmptyChunks: false
     }
   },
-  barConfig
+  stackProvidedLibsConfig
 )

--- a/packages/cozy-scripts/config/webpack.environment.dev.js
+++ b/packages/cozy-scripts/config/webpack.environment.dev.js
@@ -10,7 +10,7 @@ let plugins = [
   })
 ]
 
-// In development, the bar and cozyclientjs are provided automatically. We use the ProvidePlugin
+// In development, the bar and cozy-client-js are provided automatically. We use the ProvidePlugin
 // since it allows us to use in production the cozy.bar and cozy.client declared by the <script />
 // line injected by the stack, while in developement to have it "served" from
 // our node_modules


### PR DESCRIPTION
Cozy-Stack still provides CozyClientJS in production and few apps are
still using it. So we need to inject it in dev mode.