### PR TITLE
fix: Deactivate hot reload for production

### DIFF
--- a/packages/cozy-scripts/config/webpack.vars.js
+++ b/packages/cozy-scripts/config/webpack.vars.js
@@ -23,7 +23,8 @@ console.log(
 
 const isDebugMode = process.env[CTS.DEBUG] === 'true'
 const addAnalyzer = process.env[CTS.ANALYZER] === 'true'
-const useHotReload = process.env[CTS.HOT] === 'true'
+const useHotReload =
+  process.env[CTS.HOT] === 'true' && environment === 'development'
 const eslintFix = process.env[CTS.ESLINT_FIX] === 'true'
 const devtool =
   process.env[CTS.DEVTOOL] === 'false' ? false : process.env[CTS.DEVTOOL]


### PR DESCRIPTION
When using hot reload, CSS are loaded via the style-loader, which
uses a glob: to insert the CSS. This does not work in production
as the stack as CSP rules prohibiting this