### PR TITLE
Fix webpack config for windows

### DIFF
--- a/packages/cozy-scripts/config/webpack.config.cozy-ui.js
+++ b/packages/cozy-scripts/config/webpack.config.cozy-ui.js
@@ -14,7 +14,7 @@ module.exports = {
     rules: [
       {
         test: /\.styl$/,
-        exclude: /(node_modules|cozy-ui\/react)/,
+        exclude: /(node_modules|cozy-ui(\/|\\)react)/,
         use: [
           getCSSLoader(),
           {

--- a/packages/cozy-scripts/config/webpack.config.cozy-ui.react.js
+++ b/packages/cozy-scripts/config/webpack.config.cozy-ui.react.js
@@ -10,7 +10,7 @@ module.exports = {
     rules: [
       {
         test: /\.styl$/,
-        include: /(cozy-ui\/react)/,
+        include: /(cozy-ui(\/|\\)react)/,
         use: [
           getCSSLoader(),
           {

--- a/packages/cozy-scripts/config/webpack.config.css-modules.js
+++ b/packages/cozy-scripts/config/webpack.config.css-modules.js
@@ -15,7 +15,7 @@ module.exports = {
     rules: [
       {
         test: /\.styl$/,
-        exclude: /(node_modules|cozy-ui\/react)/,
+        exclude: /(node_modules|cozy-ui(\/|\\)react)/,
         use: [
           getCSSLoader(),
           {

--- a/packages/cozy-scripts/config/webpack.config.pictures.js
+++ b/packages/cozy-scripts/config/webpack.config.pictures.js
@@ -9,7 +9,7 @@ module.exports = {
     rules: [
       {
         test: /\.svg$/,
-        include: /\/(sprites|icons)\//,
+        include: /(\/|\\)(sprites|icons)(\/|\\)/,
         loader: require.resolve('svg-sprite-loader'),
         options: {
           symbolId: '[name]_[hash]'
@@ -17,7 +17,7 @@ module.exports = {
       },
       {
         test: /\.(png|gif|jpe?g|svg)$/i,
-        exclude: /\/(sprites|icons|public)\//,
+        exclude: /(\/|\\)(sprites|icons|public)(\/|\\)/,
         loader: require.resolve('file-loader'),
         options: {
           // mobile app needs relative path since it uses file://

--- a/packages/cozy-scripts/config/webpack.config.react.js
+++ b/packages/cozy-scripts/config/webpack.config.react.js
@@ -13,7 +13,7 @@ module.exports = {
     rules: [
       {
         test: /\.jsx$/,
-        exclude: /node_modules\/(?!(cozy-ui))/,
+        exclude: /node_modules(\/|\\)(?!(cozy-ui))/,
         loader: require.resolve('babel-loader'),
         options: {
           cacheDirectory: 'node_modules/.cache/babel-loader/react',

--- a/packages/cozy-scripts/config/webpack.environment.dev.js
+++ b/packages/cozy-scripts/config/webpack.environment.dev.js
@@ -27,7 +27,7 @@ const stackProvidedLibsConfig = {
   module: {
     rules: [
       {
-        test: /cozy-bar\/dist\/cozy-bar\.min\.js$/,
+        test: /cozy-bar(\/|\\)dist(\/|\\)cozy-bar\.min\.js$/,
         // Automatically import the CSS if the JS is imported.
         // imports-loader@0.8.0 works but imports-loader@1.0.0 does not
         loader: 'imports-loader?css=./cozy-bar.min.css'


### PR DESCRIPTION
replace "\/" by "(\/|\\)" to be handle by windows