### PR TITLE
Simplify README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,59 +39,62 @@ __You can find a complete tutorial about creating a Cozy application using `crea
  - a running [Cozy development environment](https://docs.cozy.io/en/dev/app/#install-the-development-environment)
 
 
-### Running it via Yarn directly (highly recommended)
+### Bootstrap an application
 
-You can use `create-cozy-app` without installing it globally by using the `yarn create cozy-app` command to bootstrap your application:
+You can use `create-cozy-app` without installing it globally using `yarn create`
+([yarn create documentation](https://yarnpkg.com/lang/en/docs/cli/create/)):
 
 ```
 yarn create cozy-app mycozyapp
 ```
 
-You can find more information about `yarn create` in the [yarnpkg documentation](https://yarnpkg.com/lang/en/docs/cli/create/).
+<details>
+  <summary>
+    You can also install the package globally.
 
-### Running it using the installed CLI
-
-By installed the CLI, you will have to update it regularly to keep the app template up to date. It is why we recommend to use directly `yarn` like above which will always uses the last version of the CLI.
-
-#### Install
-
-Just use `yarn` to download and globally install the `create-cozy-app` CLI;
+  </summary>
 
 ```
 yarn global add create-cozy-app
-```
-
-#### CLI usage
-
-Then, use the `create-cozy-app` command to bootstrap your application:
-
-```
 create-cozy-app mycozyapp
 ```
 
-### Ready to go
+⚠️ By using a locally installed CLI, you will have to update it regularly to keep the app
+template up to date. It is why we recommend to use directly `yarn create` which will always uses
+the latest version of the CLI.
 
-The script will download some dependencies (may take a while) and ask you a few questions, then creates an application skeleton inside `mycozyapp`.
+</details>
 
-#### With stack from docker
+It will 
 
-That's it! You can already start hacking:
+* download dependencies (it may take a while, you can go grab a coffee)
+* ask you a few questions
+* then create an application skeleton inside `mycozyapp`.
 
-```
-cd mycozyapp
-yarn start --stack
-```
+### Start developing
 
-After the webpack build and the docker environment ready, the `mycozyapp` app here will be available at http://mycozyapp.cozy.tools:8080
+ℹ️ See [this tutorial](https://docs.cozy.io/en/tutorials/app/) for more information on
+how to develop a cozy-app. Below, you'll find just the essential.
 
-#### With stack from source
-
-That's it! You can already start hacking:
+You can start developing with:
 
 ```
 cd mycozyapp
 yarn start
 ```
+
+This starts a `webpack-dev-server` that continuously builds the application
+into the `build` folder.
+
+If not already started, you should start a `cozy-stack` serving this folder:
+
+```bash
+touch ~/cozy.yaml # You can edit this file to configure the stack
+docker run -ti --rm -p 8080:8080 -p 5984:5984 -p 8025:8025 -v (pwd)/build:/data/cozy-app/mycozyapp -v ~/cozy.yaml:/etc/cozy/cozy.yaml cozy/cozy-app-dev
+```
+
+You app should now be available at `http://mycozyapp.cozy.tools:8080`.
+
 
 ### Options
 

--- a/packages/cozy-scripts/README.md
+++ b/packages/cozy-scripts/README.md
@@ -1,4 +1,4 @@
-<h1 align="center">Cozy Scripts</h1>
+# Cozy Scripts
 
 <div align="center">
   <a href="https://www.npmjs.com/package/cozy-scripts">
@@ -26,98 +26,14 @@
 
 </br>
 
-### What's cozy-scripts?
+## What's cozy-scripts?
 
-`cozy-scripts` is a script bundle partially designed to be run by
-`create-cozy-app`. This latter will just create the root folder and then run
-the `node_modules/cozy-scripts/scripts/init.js` script inside it with some CLI
-options.
+`cozy-scripts` contains
 
-All the application template outline is then handled by `cozy-scripts`.
+- common command used by Cozy developers during application development
+- common webpack configs
 
-To install:
-
-```
-yarn add --dev cozy-scripts
-```
-
-> If your purpose is to create an new application from scratch, don't install
-> `cozy-scripts` but see
-> [`create-cozy-app`](https://github.com/CPatchane/create-cozy-app/tree/master/packages/create-cozy-app)
-> instead.
-
-### Default template (`template` folder)
-
-Using the default template, `cozy-scripts` will generate a React application.
-After the initialisation, you should have the following folder structure:
-
-<details>
-
-```
-mycozyapp/
-    babel.config.js
-    CONTRIBUTING.md
-    LICENSE
-    README.md
-    jest.config.js
-    manifest.webapp
-    node_modules/
-    package.json
-    yarn.lock
-    src/
-        assets/
-        components/
-            App.jsx
-            Sidebar.jsx
-            HelloViews/
-            Todos/
-        connections/allTodos.js
-        locales/en.json
-        styles/
-        targets/
-            browser/
-                index.ejs
-                index.jsx
-            intents/
-            mobile/
-            vendor/
-    test/
-    .editorconfig
-    .eslintrc.json
-    .github/
-        .ISSUE_TEMPLATE
-        .PULL_REQUEST_TEMPLATE
-    .gitignore
-    .stylintrc
-    .travis.yml
-    .tx/
-        config
-```
-
-</details>
-
-This application is more than a simple Hello World, it's a mini Todo
-application doing interactions and data handling (using
-[`cozy-client`](https://github.com/cozy/cozy-client)) with the stack. A good
-way to understand how the application works with the Cozy.
-
-
-### Ready to go
-
-The script will download dependencies (may take a while) and ask you a few
-questions, then create an application skeleton inside `mycozyapp`.
-
-That's all! You can start developing:
-
-```
-cd mycozyapp
-yarn start
-```
-
-After the webpack build and the docker environment is ready, your app should
-be available at http://mycozyapp.cozy.tools:8080
-
-### The `cozy-scripts` CLI
+## CLI commands
 
 `cozy-scripts` has commands to be used inside your application (used by
 default in applications created from `create-cozy-app`):

--- a/packages/cozy-scripts/README.md
+++ b/packages/cozy-scripts/README.md
@@ -28,7 +28,10 @@
 
 ### What's cozy-scripts?
 
-`cozy-scripts` is a script bundle partially designed to be run by `create-cozy-app`. This latter will just create the root folder and then run the `node_modules/cozy-scripts/scripts/init.js` script inside it with some CLI options.
+`cozy-scripts` is a script bundle partially designed to be run by
+`create-cozy-app`. This latter will just create the root folder and then run
+the `node_modules/cozy-scripts/scripts/init.js` script inside it with some CLI
+options.
 
 All the application template outline is then handled by `cozy-scripts`.
 
@@ -38,11 +41,15 @@ To install:
 yarn add --dev cozy-scripts
 ```
 
-> If your purpose is to create an new application from scratch, don't install `cozy-scripts` but see [`create-cozy-app`](https://github.com/CPatchane/create-cozy-app/tree/master/packages/create-cozy-app) instead.
+> If your purpose is to create an new application from scratch, don't install
+> `cozy-scripts` but see
+> [`create-cozy-app`](https://github.com/CPatchane/create-cozy-app/tree/master/packages/create-cozy-app)
+> instead.
 
 ### Default template (`template` folder)
 
-Using the default template, `cozy-scripts` will generate a React application. After the initialisation, you should have the following folder structure:
+Using the default template, `cozy-scripts` will generate a React application.
+After the initialisation, you should have the following folder structure:
 
 <details>
 
@@ -89,94 +96,137 @@ mycozyapp/
 
 </details>
 
-This application is more than a simple Hello World, it's a mini Todo application doing interactions and data handling (using our new [`cozy-client`](https://github.com/cozy/cozy-client)) with the stack. A good way to understand how the application works with the Cozy.
+This application is more than a simple Hello World, it's a mini Todo
+application doing interactions and data handling (using
+[`cozy-client`](https://github.com/cozy/cozy-client)) with the stack. A good
+way to understand how the application works with the Cozy.
 
 
 ### Ready to go
 
-The script will download some dependencies (may take a while) and ask you a few questions, then create an application skeleton inside `mycozyapp`.
+The script will download dependencies (may take a while) and ask you a few
+questions, then create an application skeleton inside `mycozyapp`.
 
-That's all! You can start hacking:
+That's all! You can start developing:
 
 ```
 cd mycozyapp
 yarn start
 ```
 
-After the webpack build and the docker environment ready, your app should be available at http://mycozyapp.cozy.tools:8080
+After the webpack build and the docker environment is ready, your app should
+be available at http://mycozyapp.cozy.tools:8080
 
 ### The `cozy-scripts` CLI
 
-`cozy-scripts` make available some scripts to be used inside your application (used by default in applications created from `create-cozy-app`):
+`cozy-scripts` has commands to be used inside your application (used by
+default in applications created from `create-cozy-app`):
 
 ##### - `cozy-scripts --show-config`
 
-This command will output the webpack config computed according your current global variable `NODE_ENV`. By default, the application will have some `yarn` scripts (in the `package.json`) to show the configurations according to different environments (dev, browser, mobile, prod...).
+This command outputs the webpack config computed according your current global
+variable `NODE_ENV`. By default, the application will have `yarn` scripts (in
+the `package.json`) to show the configurations according to different
+environments (dev, browser, mobile, prod...).
 
 ##### - `cozy-scripts build`
 
-This command will run webpack in a one shot execution of webpack (without files watching mode so) in a quiter way. It's recommended for production build.
-The built files (destined to the Cozy) will be in `build/`.
+Runs webpack for production builds. Built files (destined to the Cozy) will be
+in the `build/` directory.
 
-> A `--debug` options is available if you want to ouput more informations about webpack building in your console.
+> A `--debug` option is available if you want to ouput more information about
+> webpack building in your console.
 
 ##### - `cozy-scripts test`
 
-Run all the application tests using internally [Jest](https://facebook.github.io/jest/). This command handles all parameters than Jest does, like `--watch` for the watch mode or `-u` to update snapshots for example.
+Runs the application tests using [Jest](https://facebook.github.io/jest/).
+This command handles all parameters than Jest does, like `--watch` for the
+watch mode or `-u` to update snapshots for example.
 
 ##### - `cozy-scripts watch`
 
-Unlike the previous command, this will run webpack using the files watching mode. Each time you will modify a file, a new build will triggered. It's recommended for development build.
-The built files (destined to the Cozy) will be in `build/`.
+Unlike the previous command, this will run webpack using the files watching
+mode. Each time you will modify a file, a new build will be triggered. It's
+recommended for development build. The built files (destined to the Cozy) will
+be in `build/`.
 
-> A `--debug` options is available if you want to ouput more informations about webpack building in your console.
+> A `--debug` options is available if you want to ouput more informations
+> about webpack building in your console.
 
 ##### - `cozy-scripts start`
 
-This is the main way to launch your application for development.
-This command will run webpack in a watching mode with a server (`webpack-dev-server`) to serve application assets.
-Then, it will launch a Cozy stack using Docker (the image `cozy/cozy-app-dev`) to serve your application inside it.
+Launches the application for development. Its runs webpack in watch mode with
+a server (`webpack-dev-server`) to serve application assets. Then, it will
+launch a Cozy stack using Docker (the image `cozy/cozy-app-dev`) to serve your
+application inside it.
 
 Your application will be available at http://<MY_APP_SLUG>.cozy.tools:8080.
 
-> In this mode [HMR (Hot Module Replacement)](https://webpack.js.org/concepts/hot-module-replacement/) is available to help you with the application development.
+> In this mode [HMR (Hot Module
+> Replacement)](https://webpack.js.org/concepts/hot-module-replacement/) is
+> available to help you with the application development.
 
 ##### - `cozy-scripts publish`
 
-This command will internally fetch and run the latest version of the [`cozy-app-publish` CLI](https://github.com/cozy/cozy-libs/tree/master/packages/cozy-app-publish) to publish your application on a Cozy registry (by default the official and main Cozy Cloud applications registry on `https://apps-registry.cozycloud.cc`). The options and arguments are the same than in the [`cozy-app-publish` package documentation](https://github.com/cozy/cozy-libs/tree/master/packages/cozy-app-publish).
+Fetches and runs the latest version of the [`cozy-app-publish`
+CLI](https://github.com/cozy/cozy-libs/tree/master/packages/cozy-app-publish)
+to publish your application on a Cozy registry (by default the official and
+main Cozy Cloud applications registry on
+`https://apps-registry.cozycloud.cc`). The options and arguments are the same
+than in the [`cozy-app-publish` package
+documentation](https://github.com/cozy/cozy-libs/tree/master/packages/cozy-app-publish).
 
 ##### - `cozy-scripts release`
 
-This command will run a script to release a new version of the application.
-The first step is to start the release using `cozy-scripts release start`. It will make a new release branch according to your current version and it will bump the version on your master branch.
-Then you can release new versions (on your release branch) using `cozy-scripts release patch|beta|stable` according to your needs.
+Releases a new version of the application. The first step is to start the
+release using `cozy-scripts release start`. It will create a new release
+branch according to your current version and it will bump the version on your
+master branch. Then you can release new versions (on your release branch)
+using `cozy-scripts release patch|beta|stable` according to your needs.
 
-By default, this script will push on your git `origin` remote but you can change by passing it to your script after the action name: `cozy-scripts release start cozy` to use the remote named `cozy`.
+By default, this script will push on the `origin` remote but you can change by
+passing it to your script after the action name: `cozy-scripts release start
+cozy` to use the remote named `cozy`.
 
-__You can find more informations about this library and how to use it in [`cozy-release` documentation](https://github.com/cozy/cozy-libs/tree/master/packages/cozy-app-publish)__
+__You can find more informations about this library and how to use it in
+[`cozy-release`
+documentation](https://github.com/cozy/cozy-libs/tree/master/packages/cozy-app-publish)__
 
-> :warning: __BE VERY CAREFUL__ using this script since __it will push directly to your remote repository__. A prompt will warn you before starting the release.
+> :warning: __BE VERY CAREFUL__ using this script since __it will push
+>     directly to your remote repository__. A prompt will warn you before
+>     starting the release.
 
 
 ##### - `--production` or `--development` options
 
-Allow to pass the wanted build mode to `cozy-scripts`. This mode will be overwritten by `process.env.NODE_ENV` usage (ex: `browser:development` for development usage with browser target).
+Allow to pass the wanted build mode to `cozy-scripts`. This mode will be
+overwritten by `process.env.NODE_ENV` usage (ex: `browser:development` for
+development usage with browser target).
 
 ##### - `--browser` or `--mobile` options
 
-Allow to pass the wanted build target to `cozy-scripts`. This target will be overwritten by `process.env.NODE_ENV` usage (ex: `browser:development` for development usage with browser target).
+Allow to pass the wanted build target to `cozy-scripts`. This target will be
+overwritten by `process.env.NODE_ENV` usage (ex: `browser:development` for
+development usage with browser target).
 
 ##### - `--analyzer`
 
-Use this option if you want to analyze your builds content using the webpack plugin [`webpack-bundle-analyzer`](https://github.com/webpack-contrib/webpack-bundle-analyzer). It will open you browser with an interactive treemap visualization of the contents of all your bundles.
+Use this option if you want to analyze your builds content using the webpack
+plugin
+[`webpack-bundle-analyzer`](https://github.com/webpack-contrib/webpack-bundle-analyzer).
+It will open you browser with an interactive treemap visualization of the
+contents of all your bundles.
 
 ##### - `--stack`
 
-Use this option if you want to run `cozy-scripts start` with launching the Cozy stack using docker. 
+Use this option if you want to run `cozy-scripts start` with launching the
+Cozy stack using docker.
 
 ##### - Custom paths providing options: `--src-dir`, `--build-dir`, `--manifest`
 
-Use these options if you want to `build`/`watch`/`start` your application with custom paths. These paths __must be relative to the application root directory__:
+Use these options if you want to `build`/`watch`/`start` your application with
+custom paths. These paths __must be relative to the application root
+directory__:
 
 - `--src-dir`: the `src` directory, the source files of your application
 - `--build-dir`: the directory to put the application build files into
@@ -184,7 +234,11 @@ Use these options if you want to `build`/`watch`/`start` your application with c
 
 ### The `cozy-scripts` webpack configuration
 
-`cozy-scripts` is designed to use a default webpack configuration for a basic React/Redux application which uses `cozy-ui` and `cozy-client-js`. But you can override or use your custom configuration files by creating a new `app.config.js` file in your application root folder. Here is an example to overload the default bundle config with a custom one:
+`cozy-scripts` is designed to use a default webpack configuration for a basic
+React/Redux application which uses `cozy-ui` and `cozy-client-js`. But you can
+override or use your custom configuration files by creating a new
+`app.config.js` file in your application root folder. Here is an example to
+overload the default bundle config with a custom one:
 
 ```javascript
 // myapp/app.config.js
@@ -196,7 +250,10 @@ module.exports = [
 ```
 
 ### `cozy-scripts` & `cozy-flags`
-`cozy-scripts` works well with [cozy-flags](https://www.npmjs.com/package/cozy-flags). You can specify a few flags on build time : 
+
+`cozy-scripts` works well with
+[cozy-flags](https://www.npmjs.com/package/cozy-flags). You can specify a few
+flags on build time :
 
 ```
 COZY_FLAGS=flag1,flag2 yarn build
@@ -211,11 +268,19 @@ if (flag('flag1') || flag('flag2')) {
 ```
 
 
-You can find more information about webpack configuration files available via `cozy-scripts` in the dedicated [webpack configs documentation](docs/webpack-configs.md).
+You can find more information about webpack configuration files available via
+`cozy-scripts` in the dedicated [webpack configs
+documentation](docs/webpack-configs.md).
 
-If you need more particular/complicated configurations and need to use the [`webpack-merge`](https://github.com/survivejs/webpack-merge#merging-with-strategies) smart mode or merge strategies, you can also find more information about in the dedicated [merge strategies documentation](docs/webpack-merge-strategies.md).
+If you need more particular/complicated configurations and need to use the
+[`webpack-merge`](https://github.com/survivejs/webpack-merge#merging-with-strategies)
+smart mode or merge strategies, you can also find more information about in
+the dedicated [merge strategies
+documentation](docs/webpack-merge-strategies.md).
 
-> :warning: `cozy-scripts` internally uses __Webpack v4__, be sure to use Webpack 4 compatible configurations if you want to provide some custom __configurations in the `app.config.js`__
+> :warning: `cozy-scripts` internally uses __Webpack v4__, be sure to use
+>     Webpack 4 compatible configurations if you want to provide some custom
+>     __configurations in the `app.config.js`__
 
 ## Community
 

--- a/packages/cozy-scripts/README.md
+++ b/packages/cozy-scripts/README.md
@@ -33,19 +33,27 @@
 - common command used by Cozy developers during application development
 - common webpack configs
 
+## Installation
+
+```
+yarn add cozy-scripts
+```
+
+After installation, the `cozy-scripts` is available.
+
 ## CLI commands
 
 `cozy-scripts` has commands to be used inside your application (used by
 default in applications created from `create-cozy-app`):
 
-##### - `cozy-scripts --show-config`
+### - `cozy-scripts --show-config`
 
-This command outputs the webpack config computed according your current global
+Outputs the webpack config computed according your current global
 variable `NODE_ENV`. By default, the application will have `yarn` scripts (in
 the `package.json`) to show the configurations according to different
 environments (dev, browser, mobile, prod...).
 
-##### - `cozy-scripts build`
+### - `cozy-scripts build`
 
 Runs webpack for production builds. Built files (destined to the Cozy) will be
 in the `build/` directory.
@@ -53,23 +61,18 @@ in the `build/` directory.
 > A `--debug` option is available if you want to ouput more information about
 > webpack building in your console.
 
-##### - `cozy-scripts test`
 
-Runs the application tests using [Jest](https://facebook.github.io/jest/).
-This command handles all parameters than Jest does, like `--watch` for the
-watch mode or `-u` to update snapshots for example.
+### - `cozy-scripts watch`
 
-##### - `cozy-scripts watch`
-
-Unlike the previous command, this will run webpack using the files watching
-mode. Each time you will modify a file, a new build will be triggered. It's
+Unlike the previous command, this will run webpack in watch mode: each time you
+modify a file, a new build will be triggered. It's
 recommended for development build. The built files (destined to the Cozy) will
 be in `build/`.
 
-> A `--debug` options is available if you want to ouput more informations
+> A `--debug` options is available if you want to ouput more information
 > about webpack building in your console.
 
-##### - `cozy-scripts start`
+### - `cozy-scripts start`
 
 Launches the application for development. Its runs webpack in watch mode with
 a server (`webpack-dev-server`) to serve application assets. Then, it will
@@ -82,7 +85,47 @@ Your application will be available at http://<MY_APP_SLUG>.cozy.tools:8080.
 > Replacement)](https://webpack.js.org/concepts/hot-module-replacement/) is
 > available to help you with the application development.
 
-##### - `cozy-scripts publish`
+### Common flags for `build` / `watch` / `start`
+
+#### `--production` / `--development`
+
+Configures the build mode.
+
+This mode will be overwritten by `process.env.NODE_ENV` (ex:
+`browser:development` for development usage with browser target).
+
+#### `--browser` / `--mobile`
+
+Configures the build target.
+
+This target will be overwritten by `process.env.NODE_ENV` (ex:
+`browser:development` for development usage with browser target).
+
+#### `--analyzer`
+
+Use this option if you want to analyze your builds content using the webpack
+plugin
+[`webpack-bundle-analyzer`](https://github.com/webpack-contrib/webpack-bundle-analyzer).
+It will open you browser with an interactive treemap visualization of the
+contents of all your bundles.
+
+##### `--src-dir`, `--build-dir`, `--manifest`
+
+Use these options if you want to `build`/`watch`/`start` your application with
+custom paths. These paths __must be relative to the application root
+directory__:
+
+- `--src-dir`: the `src` directory, the source files of your application
+- `--build-dir`: the directory to put the application build files into
+- `--manifest`: the path of your manifest file `manifest.webapp` (the `.webapp` extension must be provided)
+
+### - `cozy-scripts test`
+
+Runs the application tests using [Jest](https://facebook.github.io/jest/).
+This command handles all parameters than Jest does, like `--watch` for the
+watch mode or `-u` to update snapshots for example.
+
+### - `cozy-scripts publish`
 
 Fetches and runs the latest version of the [`cozy-app-publish`
 CLI](https://github.com/cozy/cozy-libs/tree/master/packages/cozy-app-publish)
@@ -92,7 +135,7 @@ main Cozy Cloud applications registry on
 than in the [`cozy-app-publish` package
 documentation](https://github.com/cozy/cozy-libs/tree/master/packages/cozy-app-publish).
 
-##### - `cozy-scripts release`
+### - `cozy-scripts release`
 
 Releases a new version of the application. The first step is to start the
 release using `cozy-scripts release start`. It will create a new release
@@ -113,42 +156,12 @@ documentation](https://github.com/cozy/cozy-libs/tree/master/packages/cozy-app-p
 >     starting the release.
 
 
-##### - `--production` or `--development` options
-
-Allow to pass the wanted build mode to `cozy-scripts`. This mode will be
-overwritten by `process.env.NODE_ENV` usage (ex: `browser:development` for
-development usage with browser target).
-
-##### - `--browser` or `--mobile` options
-
-Allow to pass the wanted build target to `cozy-scripts`. This target will be
-overwritten by `process.env.NODE_ENV` usage (ex: `browser:development` for
-development usage with browser target).
-
-##### - `--analyzer`
-
-Use this option if you want to analyze your builds content using the webpack
-plugin
-[`webpack-bundle-analyzer`](https://github.com/webpack-contrib/webpack-bundle-analyzer).
-It will open you browser with an interactive treemap visualization of the
-contents of all your bundles.
-
 ##### - `--stack`
 
 Use this option if you want to run `cozy-scripts start` with launching the
 Cozy stack using docker.
 
-##### - Custom paths providing options: `--src-dir`, `--build-dir`, `--manifest`
-
-Use these options if you want to `build`/`watch`/`start` your application with
-custom paths. These paths __must be relative to the application root
-directory__:
-
-- `--src-dir`: the `src` directory, the source files of your application
-- `--build-dir`: the directory to put the application build files into
-- `--manifest`: the path of your manifest file `manifest.webapp` (the `.webapp` extension must be provided)
-
-### The `cozy-scripts` webpack configuration
+### Webpack configurations
 
 `cozy-scripts` is designed to use a default webpack configuration for a basic
 React/Redux application which uses `cozy-ui` and `cozy-client-js`. But you can
@@ -165,7 +178,7 @@ module.exports = [
 ]
 ```
 
-### `cozy-scripts` & `cozy-flags`
+### `cozy-flags`
 
 `cozy-scripts` works well with
 [cozy-flags](https://www.npmjs.com/package/cozy-flags). You can specify a few
@@ -188,14 +201,14 @@ You can find more information about webpack configuration files available via
 `cozy-scripts` in the dedicated [webpack configs
 documentation](docs/webpack-configs.md).
 
-If you need more particular/complicated configurations and need to use the
+If you need more custom configurations and need to use the
 [`webpack-merge`](https://github.com/survivejs/webpack-merge#merging-with-strategies)
 smart mode or merge strategies, you can also find more information about in
 the dedicated [merge strategies
 documentation](docs/webpack-merge-strategies.md).
 
 > :warning: `cozy-scripts` internally uses __Webpack v4__, be sure to use
->     Webpack 4 compatible configurations if you want to provide some custom
+>     Webpack 4 compatible configurations if you want to provide custom
 >     __configurations in the `app.config.js`__
 
 ## Community

--- a/packages/cozy-scripts/README.md
+++ b/packages/cozy-scripts/README.md
@@ -166,11 +166,6 @@ documentation](https://github.com/cozy/cozy-libs/tree/master/packages/cozy-app-p
 >     starting the release.
 
 
-##### - `--stack`
-
-Use this option if you want to run `cozy-scripts start` with launching the
-Cozy stack using docker.
-
 ### Webpack configurations
 
 `cozy-scripts` is designed to use a default webpack configuration for a basic

--- a/packages/cozy-scripts/README.md
+++ b/packages/cozy-scripts/README.md
@@ -26,6 +26,17 @@
 
 </br>
 
+<!-- MarkdownTOC autolink=true levels=1,2 -->
+
+- [What's cozy-scripts?](#whats-cozy-scripts)
+- [Installation](#installation)
+- [CLI commands](#cli-commands)
+- [Community](#community)
+- [License](#license)
+
+<!-- /MarkdownTOC -->
+
+
 ## What's cozy-scripts?
 
 `cozy-scripts` contains
@@ -222,7 +233,10 @@ documentation](docs/webpack-merge-strategies.md).
  </div>
  </br>
 
-[Cozy] is a platform that brings all your web services in the same private space.  With it, your webapps and your devices can share data easily, providing you with a new experience. You can install Cozy on your own hardware where no one's tracking you.
+[Cozy] is a platform that brings all your web services in the same private
+space.  With it, your webapps and your devices can share data easily,
+providing you with a new experience. You can install Cozy on your own hardware
+where no one's tracking you.
 
 ### Get in touch
 

--- a/packages/cozy-scripts/README.md
+++ b/packages/cozy-scripts/README.md
@@ -40,7 +40,7 @@
 
 `cozy-scripts` contains
 
-- common command used by Cozy developers during application development
+- common commands used by Cozy developers during application development
 - common webpack configs
 
 ## Installation

--- a/packages/cozy-scripts/README.md
+++ b/packages/cozy-scripts/README.md
@@ -1,30 +1,29 @@
 # Cozy Scripts
 
-<div align="center">
-  <a href="https://www.npmjs.com/package/cozy-scripts">
-    <img src="https://img.shields.io/npm/v/cozy-scripts.svg" alt="npm version" />
-  </a>
-  <a href="https://github.com/CPatchane/create-cozy-app/blob/master/packages/cozy-scripts/LICENSE">
-    <img src="https://img.shields.io/npm/l/cozy-scripts.svg" alt="license" />
-  </a>
-  <a href="https://travis-ci.org/CPatchane/create-cozy-app">
-    <img src="https://img.shields.io/travis/CPatchane/create-cozy-app.svg" alt="travis" />
-  </a>
-  <a href="https://npmcharts.com/compare/cozy-scripts">
-    <img src="https://img.shields.io/npm/dm/cozy-scripts.svg" alt="npm downloads" />
-  </a>
-  <a href="https://david-dm.org/cpatchane/create-cozy-app?path=packages/cozy-scripts">
-    <img src="https://david-dm.org/cpatchane/create-cozy-app/status.svg?path=packages/cozy-scripts" alt="david-dm" />
-  </a>
-  <a href="https://renovateapp.com/">
-    <img src="https://img.shields.io/badge/renovate-enabled-brightgreen.svg" alt="renovate" />
-  </a>
-  <a href="https://github.com/facebook/jest">
-    <img src="https://facebook.github.io/jest/img/jest-badge.svg" alt="tested with jest" />
-  </a>
-</div>
+<a href="https://www.npmjs.com/package/cozy-scripts">
+  <img src="https://img.shields.io/npm/v/cozy-scripts.svg" alt="npm version" />
+</a>
+<a href="https://github.com/CPatchane/create-cozy-app/blob/master/packages/cozy-scripts/LICENSE">
+  <img src="https://img.shields.io/npm/l/cozy-scripts.svg" alt="license" />
+</a>
+<a href="https://travis-ci.org/CPatchane/create-cozy-app">
+  <img src="https://img.shields.io/travis/CPatchane/create-cozy-app.svg" alt="travis" />
+</a>
+<a href="https://npmcharts.com/compare/cozy-scripts">
+  <img src="https://img.shields.io/npm/dm/cozy-scripts.svg" alt="npm downloads" />
+</a>
+<a href="https://david-dm.org/cpatchane/create-cozy-app?path=packages/cozy-scripts">
+  <img src="https://david-dm.org/cpatchane/create-cozy-app/status.svg?path=packages/cozy-scripts" alt="david-dm" />
+</a>
+<a href="https://renovateapp.com/">
+  <img src="https://img.shields.io/badge/renovate-enabled-brightgreen.svg" alt="renovate" />
+</a>
+<a href="https://github.com/facebook/jest">
+  <img src="https://facebook.github.io/jest/img/jest-badge.svg" alt="tested with jest" />
+</a>
 
-</br>
+<br/>
+<br/>
 
 <!-- MarkdownTOC autolink=true levels=1,2 -->
 


### PR DESCRIPTION
- Re-orders some paragraphs to be nearer to related paragraphs
- Correct grammatical errors

- Removes --stack option that we do not use.

IMHO we should not support options that we do not use internally
as we do not have enough bandwidth to improve them, and we do
not fully understand them. We should let the community build
things.