### PR TITLE
fix: Use cozy-scripts v5

### DIFF
--- a/packages/cozy-scripts/template/package.json
+++ b/packages/cozy-scripts/template/package.json
@@ -31,7 +31,7 @@
   "homepage": "https://github.com/<USERNAME_GH>/<SLUG_GH>#readme",
   "devDependencies": {
     "babel-preset-cozy-app": "1.2.5",
-    "cozy-scripts": "4",
+    "cozy-scripts": "5",
     "enzyme": "3.8.0",
     "enzyme-adapter-react-16": "1.9.1",
     "git-directory-deploy": "1.5.1",


### PR DESCRIPTION
Creating a new version from scratch result in : "warning package.json: "dependencies" has dependency "cozy-scripts" with range "5.0.1" that collides with a dependency in "devDependencies" of the same name with version "4"" 