### PR TITLE
fix: Add relative node_modules in resolve.modules

### DIFF
--- a/packages/cozy-scripts/config/webpack.config.base.js
+++ b/packages/cozy-scripts/config/webpack.config.base.js
@@ -17,7 +17,9 @@ const production = environment === 'production'
 
 module.exports = {
   resolve: {
-    modules: [paths.appSrc(), paths.appNodeModules()],
+    // It's important that node_modules here is kept relative so that
+    // inner node_modules are checked before checking the app node_modules
+    modules: [paths.appSrc(), 'node_modules', paths.appNodeModules()],
     extensions: ['.js', '.json', '.css'],
     // linked package will still be see as a node_modules package
     symlinks: false


### PR DESCRIPTION
This can help when there are conflicting dependencies, and one
dependent has a dependency inside its own node_modules

Fix https://github.com/cozy/create-cozy-app/issues/1351'