### PR TITLE
Fix font loading

### DIFF
--- a/packages/cozy-scripts/config/webpack.config.base.js
+++ b/packages/cozy-scripts/config/webpack.config.base.js
@@ -62,9 +62,16 @@ module.exports = {
   plugins: [
     new MiniCssExtractPlugin({
       // Options similar to the same options in webpackOptions.output
-      // both options are optional
-      filename: `${getFilename()}${production ? '.min' : ''}.css`,
-      chunkFilename: `${getFilename()}${production ? '.[id].min' : ''}.css`
+      // both options are optional.
+      // Slashes in filename are replaced otherwise it causes problemes since the stylesheet
+      // is generated in a nested directory, and it prevents fonts from loading as
+      // fonts are expected to be in the same directory as the CSS stylesheet.
+      filename: `${getFilename().replace(/\//g, '-')}${
+        production ? '.min' : ''
+      }.css`,
+      chunkFilename: `${getFilename().replace(/\//g, '-')}${
+        production ? '.[id].min' : ''
+      }.css`
     }),
     new PostCSSAssetsPlugin({
       test: /\.css$/,


### PR DESCRIPTION
The mobile font was not loaded as the stylesheet was put under a folder.

```
main/
  banks.css
Lato.woff
```

With this fix, we have

```
main-banks.css
Lato.woff
```