### PR TITLE
docs: Add 2 commands to start the docker image

### DIFF
--- a/packages/cozy-scripts/bin/cozy-scripts.js
+++ b/packages/cozy-scripts/bin/cozy-scripts.js
@@ -125,7 +125,8 @@ if (program.showConfig) {
     'publish',
     'release',
     'lint',
-    'check-locales'
+    'check-locales',
+    'stackDocker'
   ]
 
   if (availableScripts.includes(actionName)) {

--- a/packages/cozy-scripts/scripts/stackDocker.js
+++ b/packages/cozy-scripts/scripts/stackDocker.js
@@ -1,0 +1,36 @@
+'use strict'
+
+const spawn = require('cross-spawn')
+
+const paths = require('../utils/paths')
+
+function runDockerImage(options) {
+  const { cliArgs } = options
+  let COZY_DISABLE_CSP = 1
+  if (cliArgs && cliArgs[0] === 'prod') {
+    COZY_DISABLE_CSP = 0
+  }
+  const dockerProcess = spawn.sync(
+    'docker',
+    [
+      'run',
+      '--rm',
+      '-it',
+      '-p',
+      '8080:8080',
+      '-p',
+      '5984:5984',
+      '-e',
+      `COZY_DISABLE_CSP=${COZY_DISABLE_CSP}`,
+      '-v',
+      `${paths.appBuild()}:/data/cozy-app/app`,
+      'cozy/cozy-app-dev'
+    ],
+    {
+      stdio: 'inherit'
+    }
+  )
+  if (dockerProcess.status !== 0) throw new Error('Docker script failed.')
+}
+
+module.exports = runDockerImage

--- a/packages/cozy-scripts/template/README.md
+++ b/packages/cozy-scripts/template/README.md
@@ -41,8 +41,15 @@ $ cd <SLUG_GH>
 $ yarn start
 ```
 
-After the build and the stack launched, your app is now available at http://<SLUG_GH>.cozy.tools:8080.
+```sh
+# in an other terminal, run the docker image 
+$ cd <SLUG_GH>
+$ yarn stack:docker:dev
+``` 
 
+After the build and the docker image launched, your app is now available at http://<SLUG_GH>.cozy.tools:8080.
+
+Note: By default, HMR (Hot Module Replacement) is enabled on your front application. To have it working, we have disabled our CSP (Content Security Policy) when running `yarn stack:docker:dev`. This is not the configuration we'll have in a production environnement. To test our app in real conditions, build your application by running `yarn build` and launch the docker image with the `yarn stack:docker:prod` command.
 
 ### Living on the edge
 

--- a/packages/cozy-scripts/template/package.json
+++ b/packages/cozy-scripts/template/package.json
@@ -13,10 +13,12 @@
     "watch": "yarn watch:browser",
     "watch:browser": "cs watch --browser",
     "watch:mobile": "cs watch --mobile",
-    "start": "cs start --hot --browser",
+    "start": "cs start --browser",
     "deploy": "git-directory-deploy --directory build/ --branch ${DEPLOY_BRANCH:-build} --repo=${DEPLOY_REPOSITORY:-https://$GITHUB_TOKEN@github.com/<USERNAME_GH>/<SLUG_GH>.git}",
     "test": "cs test --verbose --coverage",
-    "cozyPublish": "git fetch origin ${DEPLOY_BRANCH:-build}:${DEPLOY_BRANCH:-build} && cs publish --token $REGISTRY_TOKEN --build-commit $(git rev-parse ${DEPLOY_BRANCH:-build})"
+    "cozyPublish": "git fetch origin ${DEPLOY_BRANCH:-build}:${DEPLOY_BRANCH:-build} && cs publish --token $REGISTRY_TOKEN --build-commit $(git rev-parse ${DEPLOY_BRANCH:-build})",
+    "stack:docker:dev": "cs stackDocker",
+    "stack:docker:prod": "cs stackDocker --prod"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
- Remove `--hot` since it's the default now 
- Add two commands to run the docker image (one with CSP enabled, one without) 