### PR TITLE
fix: Add settings permission

### DIFF
--- a/packages/cozy-scripts/template/manifest.webapp
+++ b/packages/cozy-scripts/template/manifest.webapp
@@ -24,6 +24,11 @@
       "type": "io.cozy.apps",
       "verbs": ["GET"]
     },
+    "settings": {
+      "description": "Required by the cozy-bar to display Claudy and know which applications are coming soon",
+      "type": "io.cozy.settings",
+      "verbs": ["GET"]
+    },
     "mocks todos": {
       "description": "TO REMOVE: only used as demonstration about Cozy App data interactions",
       "type": "io.mocks.todos"


### PR DESCRIPTION
This was causing 403 errors for each app run by CCA