### PR TITLE
fix: Automatic import of cozy-bar css

### DIFF
--- a/packages/cozy-scripts/config/webpack.environment.dev.js
+++ b/packages/cozy-scripts/config/webpack.environment.dev.js
@@ -30,7 +30,7 @@ const stackProvidedLibsConfig = {
         test: /cozy-bar(\/|\\)dist(\/|\\)cozy-bar\.min\.js$/,
         // Automatically import the CSS if the JS is imported.
         // imports-loader@0.8.0 works but imports-loader@1.0.0 does not
-        loader: 'imports-loader?css=./cozy-bar.min.css'
+        loader: 'imports-loader?css=../transpiled/cozy-bar.css'
       }
     ]
   }


### PR DESCRIPTION
La route du css n'était pas la bonne, étant donné que le .min.css préalablement importé n'existe plus

Remarque : par contre c'est un breaking change, et ça ne marche qu'avec les versions 8+ de cozy-bar non ?