### PR TITLE
feat: Support cozy.localhost

### DIFF
--- a/packages/cozy-scripts/scripts/start.js
+++ b/packages/cozy-scripts/scripts/start.js
@@ -73,7 +73,7 @@ module.exports = buildOptions => {
     // Necessary since we use the stack to serve our pages; otherwise
     // we have an "Invalid Host Header" error, and the hot reload does
     // not work
-    allowedHosts: ['.cozy.tools'],
+    allowedHosts: ['.cozy.tools', '.cozy.localhost'],
 
     hot: useHotReload,
     host,


### PR DESCRIPTION
Since we now use `*.cozy.localhost` for our development purpose, 
let's put it in the allowedHosts in order to avoid a flood of 
"Invalid Host / Origin Header"