### PR TITLE
feat: add typescript compilation

### DIFF
--- a/packages/cozy-scripts/README.md
+++ b/packages/cozy-scripts/README.md
@@ -185,6 +185,20 @@ module.exports = [
 ]
 ```
 
+### TypeScript
+
+TypeScript is lightly supported: type checking and linting are disabled, but files can be compiled.
+In order to use this feature your application needs to have
+`@babel/preset-env` and `@babel/preset-typescript` installed.
+Your babel config also needs to declare those presets, for instance: 
+
+```javascript
+// myapp/babel.config.js
+module.exports = {
+  presets: ['cozy-app', '@babel/typescript', '@babel/env']
+}
+```
+
 ### `cozy-flags`
 
 `cozy-scripts` works well with

--- a/packages/cozy-scripts/config/webpack.bundle.default.js
+++ b/packages/cozy-scripts/config/webpack.bundle.default.js
@@ -5,6 +5,7 @@ const { environment, target, addAnalyzer } = require('./webpack.vars')
 
 const configs = [
   require('./webpack.config.base'),
+  require('./webpack.config.typescript'),
   require('./webpack.config.chunks'),
   require('./webpack.config.react'),
   require('./webpack.config.eslint'),

--- a/packages/cozy-scripts/config/webpack.config.base.js
+++ b/packages/cozy-scripts/config/webpack.config.base.js
@@ -20,7 +20,7 @@ module.exports = {
     // It's important that node_modules here is kept relative so that
     // inner node_modules are checked before checking the app node_modules
     modules: [paths.appSrc(), 'node_modules', paths.appNodeModules()],
-    extensions: ['.js', '.json', '.css'],
+    extensions: ['.ts', '.tsx', '.js', '.json', '.css'],
     // linked package will still be see as a node_modules package
     symlinks: false
   },

--- a/packages/cozy-scripts/config/webpack.config.typescript.js
+++ b/packages/cozy-scripts/config/webpack.config.typescript.js
@@ -1,0 +1,10 @@
+module.exports = {
+  module: {
+    rules: [
+      {
+        test: /\.tsx?$/,
+        loader: require.resolve('babel-loader')
+      }
+    ]
+  }
+}

--- a/packages/cozy-scripts/package.json
+++ b/packages/cozy-scripts/package.json
@@ -64,6 +64,7 @@
     "stylus-loader": "3.0.2",
     "svg-sprite-loader": "4.2.3",
     "svgo": "1.3.2",
+    "typescript": "^4.3.5",
     "validate-npm-package-name": "3.0.0",
     "webpack": "4.42.1",
     "webpack-bundle-analyzer": "3.6.1",

--- a/packages/cozy-scripts/yarn.lock
+++ b/packages/cozy-scripts/yarn.lock
@@ -8948,6 +8948,11 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
+typescript@^4.3.5:
+  version "4.3.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.5.tgz#4d1c37cc16e893973c45a06886b7113234f119f4"
+  integrity sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==
+
 uglify-js@3.4.x:
   version "3.4.10"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.4.10.tgz#9ad9563d8eb3acdfb8d38597d2af1d815f6a755f"


### PR DESCRIPTION
This branch will allow Cozy projects to use Typescript files (from node_modules or src).

In order to have a working babel-loader, at the moment you have to `yarn add --dev @babel/preset-env @babel/preset-typescript` in your cozy app root dir (cozy babel preset has to be updated). Then you need to call the presets in `<rootDir>/babel.config.js`, like this: 
```
module.exports = {
  presets: ['cozy-app', '@babel/typescript', '@babel/env']
}
```

If you want basic ESLint support you can update your .eslintrc like this (you have to install `@typescript-eslint`): 
```
{
  "parser": "@typescript-eslint/parser",
  "plugins": ["@typescript-eslint"],
  "extends": ["cozy-app/react"],
  "rules": {
    "react/display-name": "off",
    "no-unused-vars": "warn",
    "no-case-declarations": "warn"
  }
}
```

if you want advanced ESLint support you can update your .eslintrc like that: 
```
{
  "extends": ["cozy-app/react"],
  "overrides": [
    {
      "extends": [
        "plugin:@typescript-eslint/recommended",
        "plugin:@typescript-eslint/recommended-requiring-type-checking"
      ],
      "files": ["**/*.ts", "**/*.tsx"],
      "parser": "@typescript-eslint/parser",
      "parserOptions": { "project": "./tsconfig.json" },
      "plugins": ["@typescript-eslint"]
    }
  ]
}
```

However this requires ESLint v7+. You'll have to locally hack cozy-scripts to use an updated ESLint version.