### PR TITLE
fix: Css Order

### DIFF
--- a/packages/cozy-scripts/template/app/src/targets/browser/index.ejs
+++ b/packages/cozy-scripts/template/app/src/targets/browser/index.ejs
@@ -13,13 +13,13 @@
   <% _.forEach(htmlWebpackPlugin.files.css, function(file) { %>
       <link rel="stylesheet" href="<%- file %>">
   <% }); %>
-  {{.ThemeCSS}}
   <% if (__TARGET__ === 'mobile') { %>
   <meta name="format-detection" content="telephone=no">
   <script src="cordova.js" defer></script>
   <% } else if (__STACK_ASSETS__) { %>
   {{.CozyBar}}
   <% } %>
+  {{.ThemeCSS}}
 </head>
 <div
   role="application"


### PR DESCRIPTION
ThemeCSS should be the latest injected CSS
since it can override css's variables. 

It should be after the CSS from the app but also
after the CozyBar since this lib inject its own 
CSS