### PR TITLE
chore: use rebase merge method for automerge bot

### DIFF
--- a/.github/auto-merge.yml
+++ b/.github/auto-merge.yml
@@ -5,3 +5,5 @@ requiredLabels:
 reportStatus: true
 blockingChecks:
   status: 'pending'
+mergeMethod: rebase
+deleteBranchAfterMerge: true


### PR DESCRIPTION
Automerge bot is currently broken because it tries to create a merge commit which is forbidden on this repo.
This PR switches automerge bot to rebase merge strategy.

Also delete source branch after merge (only if it resides in the same repo)