### PR TITLE
chore(travis): remove cache and check how long is pipeline

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,7 @@ language: node_js
 node_js:
 - 16
 - 12
-cache:
-  yarn: true
-  directories:
-  - node_modules
+cache: false
 jobs:
   include:
   - stage: lint


### PR DESCRIPTION
Pipeline lasts hour because cache got issues managing build using node 12 and node 16. I removed it.

Before: 1h22min => https://app.travis-ci.com/github/cozy/create-cozy-app/builds/247268281
![Capture d’écran 2022-03-08 à 10 41 59](https://user-images.githubusercontent.com/8363334/157210369-abf34911-20a3-42b8-9286-35045721655f.png)

After: 22min => https://app.travis-ci.com/github/cozy/create-cozy-app/builds/247280583
![Capture d’écran 2022-03-08 à 10 41 50](https://user-images.githubusercontent.com/8363334/157210375-39493ada-16d2-4982-9ba3-ea00fda2eaee.png)
