### PR TITLE
fix: Crashes in dev mode

### DIFF
--- a/packages/cozy-scripts/config/webpack.environment.dev.js
+++ b/packages/cozy-scripts/config/webpack.environment.dev.js
@@ -21,33 +21,39 @@ let plugins = [
 // since it allows us to use in production the cozy.bar and cozy.client declared by the <script />
 // line injected by the stack, while in developement to have it "served" from
 // our node_modules
-const stackProvidedLibsConfig = {
+let stackProvidedLibsConfig = {
   plugins: [
     new webpack.DefinePlugin({
       __STACK_ASSETS__: false
     }),
-    ...(bar && bar
-      ? new webpack.ProvidePlugin({
-          'cozy.bar': 'cozy-bar/dist/cozy-bar.min.js',
-          'cozy.client': 'cozy-client-js/dist/cozy-client.min.js'
-        })
-      : [])
-  ],
+    new webpack.ProvidePlugin({
+      'cozy.client': 'cozy-client-js/dist/cozy-client.min.js'
+    })
+  ]
+}
+
+if (bar) {
+  const newProvidePlugin = new webpack.ProvidePlugin({
+    'cozy.bar': 'cozy-bar/dist/cozy-bar.min.js'
+  })
+  stackProvidedLibsConfig.plugins.push(newProvidePlugin)
+
   // cozy-bar v8 will throw when trying to resolve cozy-bar.min.css because it doesn't exist in this version
-  ...(bar && bar.version[0] < 8
-    ? {
-        module: {
-          rules: [
-            {
-              test: /cozy-bar(\/|\\)dist(\/|\\)cozy-bar\.min\.js$/,
-              // Automatically import the CSS if the JS is imported.
-              // imports-loader@0.8.0 works but imports-loader@1.0.0 does not
-              loader: 'imports-loader?css=./cozy-bar.min.css'
-            }
-          ]
-        }
+  if (bar.version[0] < 8) {
+    const newModule = {
+      module: {
+        rules: [
+          {
+            test: /cozy-bar(\/|\\)dist(\/|\\)cozy-bar\.min\.js$/,
+            // Automatically import the CSS if the JS is imported.
+            // imports-loader@0.8.0 works but imports-loader@1.0.0 does not
+            loader: 'imports-loader?css=./cozy-bar.min.css'
+          }
+        ]
       }
-    : {})
+    }
+    stackProvidedLibsConfig = { ...stackProvidedLibsConfig, ...newModule }
+  }
 }
 
 let output = {}


### PR DESCRIPTION
When we use the `yarn start` command we get this error message in console
<img width="865" alt="Capture d’écran 2022-03-04 à 14 51 20" src="https://user-images.githubusercontent.com/14182143/156780589-ac161137-f1c3-43e7-9477-bb469d41c146.png">

I propose this fix (with the `cozy-client` decoupling proposed in this PR #1446 )