### PR TITLE
fix(build): Handling errors stats fix

### DIFF
--- a/packages/cozy-scripts/scripts/build.js
+++ b/packages/cozy-scripts/scripts/build.js
@@ -49,11 +49,11 @@ module.exports = (buildOptions, successCallback) => {
     }
 
     if (stats.hasErrors()) {
-      const errors = flatMap(stats, stat => stat.compilation.errors)
+      const errors = flatMap(stats.stats, stat => stat.compilation.errors)
       for (const error of errors) {
         console.error(error)
       }
-      throw new Error(stats[0])
+      throw new Error(stats.stats[0])
     }
 
     if (isTestMode) successCallback()


### PR DESCRIPTION
when debugging a build failing, I needed to get this property to get stats.

How to reproduce that error:
- go in a cozy application, make the build failed, example in cozy-settings, move the withLocales inside the locales folder, and yarn build.