### PR TITLE
feat(scripts): start allows hosts from nip.io

### DIFF
--- a/packages/cozy-scripts/scripts/start.js
+++ b/packages/cozy-scripts/scripts/start.js
@@ -73,7 +73,7 @@ module.exports = buildOptions => {
     // Necessary since we use the stack to serve our pages; otherwise
     // we have an "Invalid Host Header" error, and the hot reload does
     // not work
-    allowedHosts: ['.cozy.tools', '.cozy.localhost'],
+    allowedHosts: ['.cozy.tools', '.cozy.localhost', '.nip.io'],
 
     hot: useHotReload,
     host,


### PR DESCRIPTION
Useful for Cozy Native App

according to:
https://github.com/cozy/cozy-react-native/blob/master/README.md#working-with-locally-hosted-webviews