### PR TITLE
try to fix master pipeline

### DIFF
--- a/packages/cozy-scripts/scripts/build.js
+++ b/packages/cozy-scripts/scripts/build.js
@@ -49,11 +49,11 @@ module.exports = (buildOptions, successCallback) => {
     }
 
     if (stats.hasErrors()) {
-      const errors = flatMap(stats.stats, stat => stat.compilation.errors)
+      const errors = flatMap(stats, stat => stat.compilation.errors)
       for (const error of errors) {
         console.error(error)
       }
-      throw new Error(stats.stats[0])
+      throw new Error(stats[0])
     }
 
     if (isTestMode) successCallback()


### PR DESCRIPTION
Revert "fix(build): Handling errors stats fix"

This reverts commit 7f77b27a1f163c96a474aab208396e54d047379e.

___ 
One commit before : 7f77b27a1f163c96a474aab208396e54d047379e master was green: 🟢 
https://app.travis-ci.com/github/cozy/create-cozy-app/jobs/577643052

The commit enlighting errors - amking pipeline faield 7f77b27a1f163c96a474aab208396e54d047379e master is red 🔴 
https://app.travis-ci.com/github/cozy/create-cozy-app/builds/253899050

Just reverting the commit  7f77b27a1f163c96a474aab208396e54d047379e on this branch🔴 
https://app.travis-ci.com/github/cozy/create-cozy-app/builds/253919875

Pushed a branch with previous commit 7120a243 called `fixing-pipeline`
https://app.travis-ci.com/github/cozy/create-cozy-app/jobs/578530606 🔴