### PR TITLE
fix(scripts): Webpack must not duplicate the css files

### DIFF
--- a/packages/cozy-scripts/config/webpack.config.base.js
+++ b/packages/cozy-scripts/config/webpack.config.base.js
@@ -10,7 +10,8 @@ const {
   environment,
   isDebugMode,
   getCSSLoader,
-  getFilename,
+  makeCSSChunkFilename,
+  makeCSSFilename,
   getEnabledFlags
 } = require('./webpack.vars')
 const production = environment === 'production'
@@ -64,21 +65,15 @@ module.exports = {
     noParse: [/localforage\/dist/]
   },
   plugins: [
+    /*
+    Adding the `MiniCssExtractPlugin` plugin to the `webpack.config.public.js` configuration file,
+    prevents duplication of CSS files except for the CSS file in the public folder
+    which is duplicated in the root of the build.
+    It is therefore preferable to handle this case in the `makeCSSFilename` function.
+    */
     new MiniCssExtractPlugin({
-      filename: `${getFilename()}${production ? '.min' : ''}.css`,
-      chunkFilename: `${getFilename()}${production ? '.[id].min' : ''}.css`
-    }),
-    new MiniCssExtractPlugin({
-      // Options similar to the same options in webpackOptions.output
-      // both options are optional.
-      // Slashes in filename are replaced since mobile needs
-      // fonts to be in the same directory as the CSS stylesheet.
-      filename: `${getFilename().replace(/\//g, '-')}${
-        production ? '.min' : ''
-      }.css`,
-      chunkFilename: `${getFilename().replace(/\//g, '-')}${
-        production ? '.[id].min' : ''
-      }.css`
+      filename: ({ chunk: { name } }) => makeCSSFilename(name),
+      chunkFilename: makeCSSChunkFilename()
     }),
     new PostCSSAssetsPlugin({
       test: /\.css$/,

--- a/packages/cozy-scripts/config/webpack.config.services.js
+++ b/packages/cozy-scripts/config/webpack.config.services.js
@@ -4,7 +4,7 @@ const path = require('path')
 const fs = require('fs-extra')
 const webpack = require('webpack')
 const paths = require('../utils/paths')
-const { eslintFix, getFilename, target } = require('./webpack.vars')
+const { eslintFix, makeFilename, target } = require('./webpack.vars')
 
 const servicesFolder = paths.appServicesFolder()
 const servicesPaths = fs.existsSync(servicesFolder)
@@ -33,7 +33,7 @@ const config = {
   entry: servicesEntries,
   output: {
     path: paths.appServicesBuild(),
-    filename: `${getFilename(false)}.js`
+    filename: `${makeFilename(false)}.js`
   },
   target: 'node',
   optimization: {}, // reset optimization property

--- a/packages/cozy-scripts/config/webpack.target.browser.js
+++ b/packages/cozy-scripts/config/webpack.target.browser.js
@@ -5,7 +5,7 @@ const webpack = require('webpack')
 const paths = require('../utils/paths')
 const HtmlWebpackPlugin = require('html-webpack-plugin')
 const ScriptExtHtmlWebpackPlugin = require('script-ext-html-webpack-plugin')
-const { getFilename, isDebugMode, getReactExposer } = require('./webpack.vars')
+const { makeFilename, isDebugMode, getReactExposer } = require('./webpack.vars')
 const manifest = fs.readJsonSync(paths.appManifest())
 
 const appName = manifest.name_prefix
@@ -26,7 +26,7 @@ module.exports = {
   },
   output: {
     path: paths.appBuild(),
-    filename: `${getFilename()}.js`,
+    filename: `${makeFilename()}.js`,
     pathinfo: isDebugMode
   },
   externals: {

--- a/packages/cozy-scripts/config/webpack.vars.js
+++ b/packages/cozy-scripts/config/webpack.vars.js
@@ -12,6 +12,7 @@ if (!process.env.NODE_ENV) process.env.NODE_ENV = 'browser:development'
 
 const target = process.env.NODE_ENV.match(/^(\w+):/)[1]
 const environment = process.env.NODE_ENV.match(/^\w+:(\w+)$/)[1]
+const production = environment === 'production'
 
 console.log(
   colorize.cyan(
@@ -36,10 +37,40 @@ const getCSSLoader = function() {
     : MiniCssExtractPlugin.loader
 }
 
+/**
+ * Make filename with path without extension
+ *
+ * @param  {boolean} [enableProductionHash=true] - Add hash to filename
+ * @returns {string} filename with path without extension
+ */
 const getFilename = function(enableProductionHash = true) {
   return environment === 'production' && enableProductionHash
     ? `[name]/${manifest.slug}.[contenthash]`
     : `[name]/${manifest.slug}`
+}
+
+/**
+ * Make filename with path & extension.
+ * Replace the "/" by "-" for all chunkName !== "public",
+ * in order to have the files at the root of the build
+ *
+ * @param {string} chunkName - (public, vendors, etc)
+ * @returns {string} Filename with extension
+ */
+const makeCSSFilename = chunkName => {
+  return chunkName === publicFolderName
+    ? `${getFilename()}${production ? '.min' : ''}.css`
+    : `${getFilename().replace(/\//g, '-')}${production ? '.min' : ''}.css`
+}
+/**
+ * Make chunk filename
+ *
+ * @returns {string} Filename with path without extension
+ */
+const makeCSSChunkFilename = () => {
+  return `${getFilename().replace(/\//g, '-')}${
+    production ? '.[id].min' : ''
+  }.css`
 }
 
 const getEnabledFlags = function() {
@@ -58,6 +89,8 @@ module.exports = {
   eslintFix,
   getEnabledFlags,
   getFilename,
+  makeCSSFilename,
+  makeCSSChunkFilename,
   getCSSLoader,
   isDebugMode,
   target,

--- a/packages/cozy-scripts/config/webpack.vars.js
+++ b/packages/cozy-scripts/config/webpack.vars.js
@@ -43,7 +43,7 @@ const getCSSLoader = function() {
  * @param  {boolean} [enableProductionHash=true] - Add hash to filename
  * @returns {string} filename with path without extension
  */
-const getFilename = function(enableProductionHash = true) {
+const makeFilename = function(enableProductionHash = true) {
   return environment === 'production' && enableProductionHash
     ? `[name]/${manifest.slug}.[contenthash]`
     : `[name]/${manifest.slug}`
@@ -59,8 +59,8 @@ const getFilename = function(enableProductionHash = true) {
  */
 const makeCSSFilename = chunkName => {
   return chunkName === publicFolderName
-    ? `${getFilename()}${production ? '.min' : ''}.css`
-    : `${getFilename().replace(/\//g, '-')}${production ? '.min' : ''}.css`
+    ? `${makeFilename()}${production ? '.min' : ''}.css`
+    : `${makeFilename().replace(/\//g, '-')}${production ? '.min' : ''}.css`
 }
 /**
  * Make chunk filename
@@ -68,7 +68,7 @@ const makeCSSFilename = chunkName => {
  * @returns {string} Filename with path without extension
  */
 const makeCSSChunkFilename = () => {
-  return `${getFilename().replace(/\//g, '-')}${
+  return `${makeFilename().replace(/\//g, '-')}${
     production ? '.[id].min' : ''
   }.css`
 }
@@ -88,7 +88,7 @@ module.exports = {
   environment,
   eslintFix,
   getEnabledFlags,
-  getFilename,
+  makeFilename,
   makeCSSFilename,
   makeCSSChunkFilename,
   getCSSLoader,


### PR DESCRIPTION
The CSS file that the public page needs is kept in the public folder.
fix: https://github.com/cozy/create-cozy-app/pull/1457

Example of the "build" folder (CSS view):
Before:
```
/app
   <appSlug>.<id>.min.css
/intents
   <appSlug>.<id>.min.css
/public
   <appSlug>.<id>.min.css
/vendors
app-<appSlug>.<id>.min.css
intents-<appSlug>.<id>.min.css
public-<appSlug>.<id>.min.css
vendors-<appSlug>.<id>.min.css
```
After:
```
/app
/intents
/public
   <appSlug>.<id>.min.css
/vendors
app-<appSlug>.<id>.min.css
intents-<appSlug>.<id>.min.css
vendors-<appSlug>.<id>.min.css
```
Tested with the Drive & CoachCO2 apps.