### PR TITLE
docs: Update transifex doc about in the readme

### DIFF
--- a/packages/cozy-scripts/template/README.md
+++ b/packages/cozy-scripts/template/README.md
@@ -118,10 +118,9 @@ If you want to work on <APP_NAME> and submit code modifications, feel free to op
 
 Localization and translations are handled by [Transifex][tx], which is used by all Cozy's apps.
 
-As a _translator_, you can login to [Transifex][tx-signin] (using your Github account) and claim an access to the [app repository][tx-app]. Locales are pulled when app is build before publishing.
+As a _translator_, you can login to [Transifex][tx-signin] (using your Github account) and claim an access to the [app repository][tx-app]. Transifex will then create pull request on the repository, and the locales are merged after validating the pull request.
 
-As a _developer_, you must [configure the transifex client][tx-client], and claim an access as _maintainer_ to the [app repository][tx-app]. Then please **only update** the source locale file (usually `en.json` in client and/or server parts), and push it to Transifex repository using the `tx push -s` command.
-
+As a _developer_, you have to modify json in `/src/locales`. New locales will be automatically added to Transifex. If you need to pull or push manually locales, you can use [Transifex CLI](tx-cli). If you were using a [transifex-client](tx-client), you must move to [Transifex CLI](tx-cli) to be compatible with the v3 API.
 
 ### Maintainer
 
@@ -160,7 +159,8 @@ You can reach the Cozy Community by:
 [tx]: https://www.transifex.com/cozy/
 [tx-signin]: https://www.transifex.com/signin/
 [tx-app]: https://www.transifex.com/cozy/<SLUG_TX>/dashboard/
-[tx-client]: http://docs.transifex.com/client/
+[tx-cli]: https://developers.transifex.com/docs/cli
+[tx-client]: https://github.com/transifex/transifex-client
 [libera]: https://web.libera.chat/#cozycloud
 [forum]: https://forum.cozy.io/
 [github]: https://github.com/cozy/


### PR DESCRIPTION
Transifex has migrated to a new CLI after migrating their API to v3. I have updated the documentation to match this change and also have a few lines on our methodology with the Transifex Github integration