### PR TITLE
fix: Copy cozy-bar v7 assets only if should add public config

### DIFF
--- a/packages/cozy-scripts/config/webpack.config.cozy-bar-v7.js
+++ b/packages/cozy-scripts/config/webpack.config.cozy-bar-v7.js
@@ -6,6 +6,7 @@ const {
   publicFolderName,
   intentsFolderName,
   getReactExposer,
+  shouldAddPublicConfig,
   environment,
   target
 } = require('./webpack.vars')
@@ -20,29 +21,41 @@ let cozyBarModule = {
   // Exposed variables in global scope (needed for cozy-bar)
   entry: {
     app: [getReactExposer()],
-    [publicFolderName]: [getReactExposer()],
     [intentsFolderName]: [getReactExposer()]
   },
-  plugins: [
-    new CopyPlugin([
-      {
-        from: paths.appCozyBarJs(),
-        to: buildPublicCozyBarJs
-      },
-      {
-        from: paths.appCozyBarCss(),
-        to: buildPublicCozyBarCss
-      }
-    ]),
-    new HtmlWebpackIncludeAssetsPlugin({
-      assets: [
-        `${publicFolderName}/cozy-bar.js`,
-        `${publicFolderName}/cozy-bar.css`
-      ],
-      append: false,
-      publicPath: true
-    })
-  ]
+  plugins: []
+}
+
+// We need to put all assets in the public build folder since
+// public pages will need to have them public
+if (shouldAddPublicConfig()) {
+  cozyBarModule = {
+    ...cozyBarModule,
+    entry: {
+      ...cozyBarModule.entry,
+      [publicFolderName]: [getReactExposer()]
+    },
+    plugins: [
+      new CopyPlugin([
+        {
+          from: paths.appCozyBarJs(),
+          to: buildPublicCozyBarJs
+        },
+        {
+          from: paths.appCozyBarCss(),
+          to: buildPublicCozyBarCss
+        }
+      ]),
+      new HtmlWebpackIncludeAssetsPlugin({
+        assets: [
+          `${publicFolderName}/cozy-bar.js`,
+          `${publicFolderName}/cozy-bar.css`
+        ],
+        append: false,
+        publicPath: true
+      })
+    ]
+  }
 }
 
 if (target === 'mobile') {

--- a/packages/cozy-scripts/config/webpack.config.public.js
+++ b/packages/cozy-scripts/config/webpack.config.public.js
@@ -3,9 +3,12 @@
 const HtmlWebpackPlugin = require('html-webpack-plugin')
 const fs = require('fs-extra')
 const paths = require('../utils/paths')
-const CTS = require('../utils/constants')
 const manifest = fs.readJsonSync(paths.appManifest())
-const { publicFolderName, target, useCozyClientJs } = require('./webpack.vars')
+const {
+  publicFolderName,
+  useCozyClientJs,
+  shouldAddPublicConfig
+} = require('./webpack.vars')
 
 const HtmlWebpackIncludeAssetsPlugin = require('html-webpack-include-assets-plugin')
 const CopyPlugin = require('copy-webpack-plugin')
@@ -14,15 +17,9 @@ const appName = manifest.name_prefix
   ? `${manifest.name_prefix} ${manifest.name}`
   : manifest.name
 
-/* We don't build public if no public and if on mobile build */
-const shouldAddPublicConfig = () =>
-  process.env[CTS.FORCE_PUBLIC] == 'true' ||
-  (target === 'browser' &&
-    fs.existsSync(paths.appPublicIndex()) &&
-    fs.existsSync(paths.appPublicHtmlTemplate()))
-
 const buildPublicCozyClientJs = `${paths.appBuild()}/${publicFolderName}/cozy-client-js.js`
 
+/* We don't build public if no public and if on mobile build */
 function getConfig() {
   if (shouldAddPublicConfig()) {
     const plugins = [

--- a/packages/cozy-scripts/config/webpack.vars.js
+++ b/packages/cozy-scripts/config/webpack.vars.js
@@ -87,6 +87,12 @@ const getEnabledFlags = function() {
 
 const getReactExposer = () => paths.csReactExposer()
 
+const shouldAddPublicConfig = () =>
+  process.env[CTS.FORCE_PUBLIC] == 'true' ||
+  (target === 'browser' &&
+    fs.existsSync(paths.appPublicIndex()) &&
+    fs.existsSync(paths.appPublicHtmlTemplate()))
+
 module.exports = {
   addAnalyzer,
   addCozyBarV7,
@@ -104,5 +110,6 @@ module.exports = {
   publicFolderName,
   intentsFolderName,
   getReactExposer,
+  shouldAddPublicConfig,
   devtool
 }


### PR DESCRIPTION
I made a mistake in a previous [PR](https://github.com/cozy/create-cozy-app/pull/1488) to extract cozy-bar v7 config. If you add version 7, this creates an unwanted public entry point that copies the bar source file to the public folder. This causes the build folder to grow without ever being used 🙁

This PR aims to correct this problem by only copying assts when the application needs to have the public configuration from which the config originally came (cf: [old code](https://github.com/cozy/create-cozy-app/commit/659644fa8b7b4954540ba4b698aa5f2353a9775d))