### PR TITLE
Force hash `sha256` instead of `md4`

### DIFF
--- a/packages/cozy-scripts/bin/cozy-scripts.js
+++ b/packages/cozy-scripts/bin/cozy-scripts.js
@@ -9,6 +9,13 @@ const CTS = require('../utils/constants.js')
 const regexpReplacer = require('../utils/regexpReplacer')
 const getWebpackConfigs = require('../scripts/config')
 
+// Required to work from Node version 17+
+// More info: https://github.com/webpack/webpack/issues/13572#issuecomment-923736472
+const crypto = require('crypto')
+const crypto_orig_createHash = crypto.createHash
+crypto.createHash = algorithm =>
+  crypto_orig_createHash(algorithm == 'md4' ? 'sha256' : algorithm)
+
 let actionName
 const program = new commander.Command(pkg.name)
   .description(


### PR DESCRIPTION
This change is required for Node versions >= 17

Following the issue related to OpenSSL (https://github.com/webpack/webpack/issues/13572), we decided to use this solution [https://github.com/webpack/webpack/issues/13572#issuecomment- 923736472](https://github.com/webpack/webpack/issues/13572#issuecomment-923736472), compatible with Node version 16 to 20