### PR TITLE
feat: Force NODE_ENV to "test" when run it

### DIFF
--- a/packages/cozy-scripts/scripts/test.js
+++ b/packages/cozy-scripts/scripts/test.js
@@ -3,6 +3,7 @@
 const jestAPI = require('jest')
 
 function runJest(options) {
+  if (!process.env.NODE_ENV) process.env.NODE_ENV = 'test'
   const { cliArgs } = options
 
   jestAPI.run(cliArgs)


### PR DESCRIPTION
We recently realized that the `NODE_ENV` variable was not defined during application testing.
If your application uses cozy-scripts to run tests, you can remove `env NODE_ENV=test` from your script