### PR TITLE
Remove mobile target from create-cozy-app template

### DIFF
--- a/packages/cozy-scripts/template/app/src/targets/browser/index.ejs
+++ b/packages/cozy-scripts/template/app/src/targets/browser/index.ejs
@@ -13,10 +13,7 @@
   <% _.forEach(htmlWebpackPlugin.files.css, function(file) { %>
       <link rel="stylesheet" href="<%- file %>">
   <% }); %>
-  <% if (__TARGET__ === 'mobile') { %>
-  <meta name="format-detection" content="telephone=no">
-  <script src="cordova.js" defer></script>
-  <% } else if (__STACK_ASSETS__) { %>
+  <% if (__STACK_ASSETS__) { %>
   {{.CozyBar}}
   <% } %>
   {{.ThemeCSS}}

--- a/packages/cozy-scripts/template/app/src/targets/browser/index.ejs
+++ b/packages/cozy-scripts/template/app/src/targets/browser/index.ejs
@@ -11,10 +11,10 @@
   <meta name="theme-color" content="#ffffff">
   <meta name="viewport" content="width=device-width, height=device-height, initial-scale=1, viewport-fit=cover">
   <% _.forEach(htmlWebpackPlugin.files.css, function(file) { %>
-      <link rel="stylesheet" href="<%- file %>">
+    <link rel="stylesheet" href="<%- file %>">
   <% }); %>
   <% if (__STACK_ASSETS__) { %>
-  {{.CozyBar}}
+    {{.CozyBar}}
   <% } %>
   {{.ThemeCSS}}
 </head>
@@ -23,5 +23,5 @@
   data-cozy="{{.CozyData}}"
 >
 <% _.forEach(htmlWebpackPlugin.files.js, function(file) { %>
-    <script src="<%- file %>"></script>
+  <script src="<%- file %>"></script>
 <% }); %>

--- a/packages/cozy-scripts/template/app/src/targets/mobile/DOCS.md
+++ b/packages/cozy-scripts/template/app/src/targets/mobile/DOCS.md
@@ -1,2 +1,0 @@
-# Mobile development documentation
-[Cozy Docs](https://cozy.github.io/cozy-docs-v3/en/dev/cordova/)

--- a/packages/cozy-scripts/test/__snapshots__/scripts.spec.js.snap
+++ b/packages/cozy-scripts/test/__snapshots__/scripts.spec.js.snap
@@ -109,8 +109,6 @@ Array [
   "src/targets/browser/index.jsx",
   "src/targets/browser/setupApp.jsx",
   "src/targets/intents/.gitkeep",
-  "src/targets/mobile/DOCS.md",
-  "src/targets/mobile/config.xml",
   "src/targets/vendor/assets/icon.svg",
   "src/targets/vendor/assets/manifest.json",
   "src/utils/bar.js",


### PR DESCRIPTION
create-cozy-app will be free of mobile target code. But there is still a lot of thing to remove in cozy-scripts.